### PR TITLE
Fix error handling

### DIFF
--- a/lib/read-write.js
+++ b/lib/read-write.js
@@ -9,11 +9,11 @@ const {
 
 function getRows(rows, options){
     return new Promise((resolve, reject) => {
-        if (!rows || !rows.length){reject("Need valid rows")}
-        if (!options){reject("Need valid options")}
-        if (!options.spreadsheetId || typeof options.privateKey !== "string"){reject("Need valid spreadsheetId")}
-        if (!options.clientEmail || typeof options.privateKey !== "string"){reject("Need valid clientEmail")}
-        if (!options.privateKey || typeof options.privateKey !== "string"){reject("Need valid privateKey")}
+        if (!rows || !rows.length){return reject(new Error("Need valid rows"))}
+        if (!options){return reject(new Error("Need valid options"))}
+        if (!options.spreadsheetId || typeof options.privateKey !== "string"){return reject(new Error("Need valid spreadsheetId"))}
+        if (!options.clientEmail || typeof options.privateKey !== "string"){return reject(new Error("Need valid clientEmail"))}
+        if (!options.privateKey || typeof options.privateKey !== "string"){return reject(new Error("Need valid privateKey"))}
 
         _sheets(options.clientEmail, options.privateKey).batchGet({
             spreadsheetId: options.spreadsheetId,
@@ -21,20 +21,19 @@ function getRows(rows, options){
             majorDimension: "ROWS",
             dateTimeRenderOption: options.dateTimeRenderOption || "FORMATTED_STRING"
         }, (error, response) => {
-            if (error){reject(error);}
+            if (error){return reject(error);}
             resolve(response);
         });
-    }).then(_sheetsToMappedObject.bind(null, rows))
-    .catch(console.error);
+    }).then(_sheetsToMappedObject.bind(null, rows));
 }
 
 function updateRows(data, options){
     return new Promise((resolve, reject) => {
-        if (!data || !data.length){reject("Need data")}
-        if (!options){reject("Need valid options")}
-        if (!options.spreadsheetId || typeof options.privateKey !== "string"){reject("Need valid spreadsheetId")}
-        if (!options.clientEmail || typeof options.privateKey !== "string"){reject("Need valid clientEmail")}
-        if (!options.privateKey || typeof options.privateKey !== "string"){reject("Need valid privateKey")}
+        if (!data || !data.length){return reject(new Error("Need data"))}
+        if (!options){return reject(new Error("Need valid options"))}
+        if (!options.spreadsheetId || typeof options.privateKey !== "string"){return reject(new Error("Need valid spreadsheetId"))}
+        if (!options.clientEmail || typeof options.privateKey !== "string"){return reject(new Error("Need valid clientEmail"))}
+        if (!options.privateKey || typeof options.privateKey !== "string"){return reject(new Error("Need valid privateKey"))}
 
         _sheets(options.clientEmail, options.privateKey).batchUpdate({
             spreadsheetId: options.spreadsheetId,
@@ -43,21 +42,20 @@ function updateRows(data, options){
                 data
             }
         }, (error, response) => {
-            if (error){reject(error);}
+            if (error){return reject(error);}
             resolve(response);
         });
-    }).then(response => ({updatedRows: response.totalUpdatedRows}))
-    .catch(console.error);
+    }).then(response => ({updatedRows: response.totalUpdatedRows}));
 }
 
 function addRows(range, data, options){
     return new Promise((resolve, reject) => {
-        if (!range){reject("Need range")}
-        if (!data || !data.length){reject("Need data")}
-        if (!options){reject("Need valid options")}
-        if (!options.spreadsheetId || typeof options.privateKey !== "string"){reject("Need valid spreadsheetId")}
-        if (!options.clientEmail || typeof options.privateKey !== "string"){reject("Need valid clientEmail")}
-        if (!options.privateKey || typeof options.privateKey !== "string"){reject("Need valid privateKey")}
+        if (!range){return reject(new Error("Need range"))}
+        if (!data || !data.length){return reject(new Error("Need data"))}
+        if (!options){return reject(new Error("Need valid options"))}
+        if (!options.spreadsheetId || typeof options.privateKey !== "string"){return reject(new Error("Need valid spreadsheetId"))}
+        if (!options.clientEmail || typeof options.privateKey !== "string"){return reject(new Error("Need valid clientEmail"))}
+        if (!options.privateKey || typeof options.privateKey !== "string"){return reject(new Error("Need valid privateKey"))}
 
         _sheets(options.clientEmail, options.privateKey).append({
             spreadsheetId: options.spreadsheetId,
@@ -68,11 +66,10 @@ function addRows(range, data, options){
                 values: data
             }
         }, (error, response) => {
-            if (error){reject(error)}
+            if (error){return reject(error)}
             resolve(response);
         });
-    }).then(response => ({updatedRows: response.updates.updatedRows}))
-    .catch(console.error);
+    }).then(response => ({updatedRows: response.updates.updatedRows}));    
 }
 
 module.exports = {


### PR DESCRIPTION
### `reject(new Error())` is the only way to preserve stack traces (and ones sanity)

> `reject(string)` is the road to hating promises. (The issue is **really** about how JavaScript/Node has always handled errors. Nothing actually specific to Promises.)

I think this anti-pattern is so common because languages like ruby, lua, et. al. let you error with strings.

![image](https://user-images.githubusercontent.com/397632/37443425-ac76d1e6-27d1-11e8-9a26-c22c62d6222f.png)

![image](https://user-images.githubusercontent.com/397632/37443446-d5d56476-27d1-11e8-820b-73578b3d3421.png)

